### PR TITLE
feat: enable multi-element instances #63

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,5 +1,13 @@
 ui: tape
 browsers:
+  - name: iphone
+    version: 8.0
+  - name: iphone
+    version: 9.0
+  - name: android
+    version: latest
+  - name: android
+    version: 4.4
   - name: chrome
     version: -2..latest
     platform: Linux
@@ -12,10 +20,4 @@ browsers:
     version: latest
   - name: safari
     version: '7..latest'
-  - name: iphone
-    version: '[8.0, 9.0]'
-  - name: android
-    version: latest
-  - name: android
-    version: 4.4
 html: distribution/test/integration/index.html

--- a/documentation/api.md
+++ b/documentation/api.md
@@ -18,7 +18,7 @@ Creates a new JogWheel instance
 
 **Parameters**
 
--   `element` **HTMLElement** HTMLElement to instantiate on
+-   `nodes` **Node or NodeList** Node or NodeList to instantiate on
 -   `options` **object** Options object
 -   `window` **[Window]** Global context to use (optional, default `global.window`)
 -   `document` **[Document]** Document context to use (optional, default `global.window`)
@@ -34,6 +34,10 @@ const wheel = new JogWheel(element);
 ```
 
 Returns **JogWheel** JogWheel instance
+
+# durations
+
+Returns **array** durations used by JogWheel instance
 
 # pause
 
@@ -76,6 +80,18 @@ wheel.seek(0.5).play();
 ```
 
 Returns **JogWheel** JogWheel instance
+
+# players
+
+Returns **array** WebAnimationPlayer instances by JogWheel instance
+
+# playState
+
+Returns **string** playState, either `running` or `paused`
+
+# progress
+
+Returns **float** progress in fraction of 1 [0..1]
 
 # seek
 

--- a/public/static/index.js
+++ b/public/static/index.js
@@ -5101,7 +5101,7 @@ var JogWheel = (function () {
 			return Object.seal(Object.freeze(new (_bind.apply(JogWheel, [null].concat(args)))()));
 		}
 	}, {
-		key: '_cache',
+		key: '__cache',
 		value: {
 			media: null
 		},
@@ -5109,7 +5109,7 @@ var JogWheel = (function () {
 		/**
    * Creates a new JogWheel instance
    * @constructor
-   * @param  {HTMLElement} element  HTMLElement to instantiate on
+   * @param  {Node|NodeList} nodes  Node or NodeList to instantiate on
    * @param  {object} options Options object
    * @param  {Window} [window=global.window] Global context to use
    * @param  {Document} [document=global.window] Document context to use
@@ -5124,41 +5124,49 @@ var JogWheel = (function () {
 		enumerable: true
 	}]);
 
-	function JogWheel(element, options) {
+	function JogWheel(nodes, options) {
 		var window = arguments.length <= 2 || arguments[2] === undefined ? global.window : arguments[2];
 		var document = arguments.length <= 3 || arguments[3] === undefined ? global.document : arguments[3];
 
 		_classCallCheck(this, JogWheel);
 
-		if (!element) {
+		if (!nodes) {
 			throw new Error('Could not construct JogWheel, missing element');
 		}
 
-		this.element = element;
-		this.player = (0, _getPlayerJs2['default'])(element, window, document);
-		this.settings = _extends({}, _defaultsJs2['default'], options);
-	}
+		var elements = nodes instanceof window.NodeList ? [].slice.call(nodes) : [nodes]; // eslint-disable-line prefer-reflect
+		var players = elements.map(function (element) {
+			return (0, _getPlayerJs2['default'])(element, window, document);
+		});
+		var settings = _extends({}, _defaultsJs2['default'], options);
 
-	/**
-  * Plays the animation
-  * @return {JogWheel} JogWheel instance
-  * @example
-  * import JogWheel from 'jogwheel';
-  * const element = document.querySelector('[data-animated]');
-  *
-  * // Instantiate a paused JogWheel instance on element
-  * const wheel = JogWheel.create(element, {
-  * 	paused: true
-  * });
-  *
-  * // Seek to middle of animation sequence and play
-  * wheel.seek(0.5).play();
-  */
+		this.__instance = {
+			elements: elements, players: players, settings: settings
+		};
+	}
 
 	_createClass(JogWheel, [{
 		key: 'play',
+
+		/**
+   * Plays the animation
+   * @return {JogWheel} JogWheel instance
+   * @example
+   * import JogWheel from 'jogwheel';
+   * const element = document.querySelector('[data-animated]');
+   *
+   * // Instantiate a paused JogWheel instance on element
+   * const wheel = JogWheel.create(element, {
+   * 	paused: true
+   * });
+   *
+   * // Seek to middle of animation sequence and play
+   * wheel.seek(0.5).play();
+   */
 		value: function play() {
-			this.player.play();
+			this.__instance.players.forEach(function (player) {
+				return player.play();
+			});
 			return this;
 		}
 
@@ -5180,7 +5188,9 @@ var JogWheel = (function () {
 	}, {
 		key: 'pause',
 		value: function pause() {
-			this.player.pause();
+			this.__instance.players.forEach(function (player) {
+				return player.pause();
+			});
 			return this;
 		}
 
@@ -5214,8 +5224,11 @@ var JogWheel = (function () {
 	}, {
 		key: 'seek',
 		value: function seek(progress) {
-			var duration = this.player.effect ? this.player.effect.activeDuration || this.player.effect.timing.duration : this.player._totalDuration;
-			this.player.currentTime = duration * progress;
+			this.__instance.players.forEach(function (player) {
+				var duration = player.effect ? player.effect.activeDuration || player.effect.timing.duration : player._totalDuration;
+				player.currentTime = duration * progress;
+			});
+
 			return this;
 		}
 
@@ -5280,11 +5293,21 @@ var JogWheel = (function () {
    */
 	}, {
 		key: 'render',
-		value: function render(styles) {
+		value: function render() {
 			// TODO: add documentation
 			// TODO: implement this, must proxy elemnt writes for e.g. react integration
-			this.settings.render(this.element, styles);
+			// this.settings.render(this.element, styles);
 			return this;
+		}
+	}, {
+		key: 'playState',
+		get: function get() {
+			return this.__instance.players[0].playState;
+		}
+	}, {
+		key: 'currentTime',
+		get: function get() {
+			return this.__instance.players[0].currentTime;
 		}
 	}]);
 

--- a/source/test/integration/index.js
+++ b/source/test/integration/index.js
@@ -8,7 +8,8 @@ import JogWheel from '../../library';
 const tests = [
 	'simple',
 	'keyword',
-	'iteration-count'
+	'iteration-count',
+	'node-list'
 ];
 const base = './distribution/test/integration';
 

--- a/source/test/integration/node-list/index.css
+++ b/source/test/integration/node-list/index.css
@@ -1,0 +1,32 @@
+@keyframes spin {
+	from {
+		transform: rotate(0);
+	}
+	to {
+		transform: rotate(-360deg);
+	}
+}
+
+[data-animated] {
+	display: inline-block;
+	height: 100px;
+	width: 100px;
+	overflow: hidden;
+	white-space: nowrap;
+	line-height: 100px;
+	text-align: center;
+	border-radius: 50%;
+	background: wheat;
+	animation: spin 1s linear;
+	animation-iteration-count: 100;
+	animation-play-state: paused;
+	animation-fill-mode: both;
+}
+
+[data-animated="item-2"] {
+	animation-duration: 30s;
+}
+
+[data-animated="item-2"] {
+	animation-duration: .3s;
+}

--- a/source/test/integration/node-list/index.html
+++ b/source/test/integration/node-list/index.html
@@ -1,0 +1,11 @@
+<div>
+	<div data-animated="item-1">
+		Item 1
+	</div>
+	<div data-animated="item-2">
+		Item 2
+	</div>
+	<div data-animated="item-3">
+		Item 3
+	</div>
+</div>

--- a/source/test/integration/node-list/index.js
+++ b/source/test/integration/node-list/index.js
@@ -1,0 +1,25 @@
+import 'web-animations-js';
+
+const tape = require('tape');
+const JogWheel = require('jogwheel');
+
+tape('iteration-count', t => {
+	const elements = document.querySelectorAll('[data-animated]');
+	const wheel = JogWheel.create(elements, {}, window, document);
+
+	t.doesNotThrow(() => {
+		wheel.seek(0.5);
+	});
+
+	t.doesNotThrow(() => {
+		wheel.play();
+	});
+
+	setTimeout(() => {
+		t.doesNotThrow(() => {
+			wheel.pause();
+		});
+
+		t.end();
+	}, 500);
+});

--- a/source/test/integration/simple/index.js
+++ b/source/test/integration/simple/index.js
@@ -20,6 +20,4 @@ tape('simple integration', t => {
 		wheel.play();
 		t.end();
 	}, 10);
-
-	console.log(wheel);
 });

--- a/source/test/unit/jogwheel-constructor.js
+++ b/source/test/unit/jogwheel-constructor.js
@@ -3,6 +3,7 @@ import tape from 'tape';
 import windowStub from './stubs/window.js';
 import documentStub from './stubs/document.js';
 import elementStub from './stubs/element.js';
+import nodeListStub from './stubs/node-list.js';
 
 import JogWheel from '../../library/index.js';
 
@@ -16,6 +17,11 @@ tape('constructor', t => {
 		const instance = new JogWheel(elementStub, {}, windowStub, documentStub);
 		instance.unplug();
 	}, 'should not throw when called with element');
+
+	t.doesNotThrow(() => {
+		const instance = new JogWheel(nodeListStub, {}, windowStub, documentStub);
+		instance.unplug();
+	}, 'should not throw when called with node-list');
 
 	t.end();
 });

--- a/source/test/unit/jogwheel-instance-pause.js
+++ b/source/test/unit/jogwheel-instance-pause.js
@@ -28,7 +28,7 @@ tape('instance.pause', t => {
 	runningInstance.pause();
 
 	t.equals(
-		runningInstance.player.playState,
+		runningInstance.playState,
 		'paused',
 		'should pause a running JogWheel instance'
 	);

--- a/source/test/unit/jogwheel-instance-play.js
+++ b/source/test/unit/jogwheel-instance-play.js
@@ -27,7 +27,7 @@ tape('instance.play', t => {
 	pausedInstance.play();
 
 	t.equals(
-		pausedInstance.player.playState,
+		pausedInstance.playState,
 		'running',
 		'should start a paused JogWheel instance'
 	);

--- a/source/test/unit/jogwheel-instance-seek.js
+++ b/source/test/unit/jogwheel-instance-seek.js
@@ -29,18 +29,34 @@ tape('instance.seek', t => {
 	instance.seek(0.5);
 
 	t.equals(
-		instance.player.currentTime,
-		150,
-		'should jump to correct currentTime for paused-animation'
+		instance.progress,
+		0.5,
+		'should jump to correct progress for paused-animation'
 	);
+
+	instance.players.forEach(player => {
+		t.equals(
+			player.currentTime,
+			150,
+			'should jump each player instance to correct currentTime for paused-animation'
+		);
+	});
 
 	instance.seek(0);
 
 	t.equals(
-		instance.player.currentTime,
+		instance.progress,
 		0,
-		'should jump to correct currentTime for paused-animation'
+		'should jump to correct progress for paused-animation'
 	);
+
+	instance.players.forEach(player => {
+		t.equals(
+			player.currentTime,
+			0,
+			'should jump each player instance to correct currentTime for paused-animation'
+		);
+	});
 
 	const runningElement = {
 		...elementStub,
@@ -54,17 +70,17 @@ tape('instance.seek', t => {
 	runningInstance.seek(1);
 
 	t.equals(
-		runningInstance.player.currentTime,
-		300,
-		'should jump to correct currentTime for running-animation'
+		runningInstance.progress,
+		1,
+		'should jump to correct progress for running-animation'
 	);
 
 	runningInstance.seek(0.2);
 
 	t.equals(
-		runningInstance.player.currentTime,
-		60,
-		'should jump to correct currentTime for running-animation'
+		runningInstance.progress,
+		0.2,
+		'should jump to correct progress for running-animation'
 	);
 
 	const slowElement = {
@@ -79,16 +95,16 @@ tape('instance.seek', t => {
 	slowInstance.seek(0.5);
 
 	t.equals(
-		slowInstance.player.currentTime,
-		500,
-		'should jump to correct currentTime for slow-animation'
+		slowInstance.progress,
+		0.5,
+		'should jump to correct progress for slow-animation'
 	);
 
 	slowInstance.seek(0.75);
 
 	t.equals(
-		slowInstance.player.currentTime,
-		750,
-		'should jump to correct currentTime for slow-animation'
+		slowInstance.progress,
+		0.75,
+		'should jump to correct progress for slow-animation'
 	);
 });

--- a/source/test/unit/stubs/node-list.js
+++ b/source/test/unit/stubs/node-list.js
@@ -1,0 +1,9 @@
+import windowStub from './window.js';
+import elementStub from './element.js';
+
+const nodeListStub = new windowStub.NodeList([
+	{...elementStub},
+	{...elementStub}
+]);
+
+export default nodeListStub;

--- a/source/test/unit/stubs/window.js
+++ b/source/test/unit/stubs/window.js
@@ -8,6 +8,10 @@ const windowStub = {
 	},
 	getComputedStyle(element) {
 		return element.style || {};
+	},
+	NodeList(elements) {
+		elements.forEach((element, index) => this[index] = element);
+		this.length = elements.length;
 	}
 };
 

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -20,6 +20,7 @@ module.exports = function (gulp, paths, options, cli) {
 		var transpile = require('./transpile')(gulp, paths, watchOptions, cli);
 		var documentation = require('./documentation')(gulp, paths, watchOptions, cli);
 		var lint = require('./lint')(gulp, paths, watchOptions, cli);
+		var test = require('./test')(gulp, paths, watchOptions, cli);
 		var copy = require('./copy')(gulp, paths, watchOptions, cli);
 		var copyStatic = require('./static')(gulp, paths, watchOptions, cli);
 		var html = require('./html')(gulp, paths, watchOptions, cli);
@@ -44,8 +45,18 @@ module.exports = function (gulp, paths, options, cli) {
 								task(copyStatic, 'copy-static'),
 								task(lint),
 								task(css),
-								task(sequence(task(documentation), task(html)), 'docs-html'),
-								task(sequence(task(transpile), task(pack)), 'transpile-pack')
+								task(sequence(
+									task(documentation),
+									task(html)), 'docs-html'),
+								task(sequence(
+									task(transpile),
+									task(sequence(
+										[
+											task(pack),
+											task(test)
+										]
+									), 'test-pack')),
+									'transpile-test-pack')
 							]
 						)(onError(watchOptions));
 					}


### PR DESCRIPTION
This allows for instantiation of JogWheel on NodeLists and Nodes. 

Changes:
* Rename first parameter of constructor to `node`
* Normalize `node` to `Array`
* Move all "private" members to `this.__instance`
* Add `playState` and `currentTime` getters
* Modify tests to fit extended API
* Modify writing methods to fit new internal data structures