### PR TITLE
fix: handle elements without animate method gracefully

### DIFF
--- a/source/test/unit/init-player.js
+++ b/source/test/unit/init-player.js
@@ -1,7 +1,7 @@
 import tape from 'tape';
 import windowStub from './stubs/window.js';
 import documentStub from './stubs/document.js';
-import elementStub from './stubs/element.js';
+import elementStub, {unpolyfilledElementStub} from './stubs/element.js';
 import initPlayer from '../../library/init-player.js';
 
 tape('init-player', t => {
@@ -12,6 +12,14 @@ tape('init-player', t => {
 			() => {},
 			windowStub, documentStub) === 'object',
 		'should return an object');
+
+	t.ok(
+		typeof initPlayer(unpolyfilledElementStub,
+			[],
+			{},
+			() => {},
+			windowStub, documentStub) === 'object',
+		'should return an object when initializing on element without animate method');
 
 	const stub = {...elementStub, style: {}};
 

--- a/source/test/unit/stubs/element.js
+++ b/source/test/unit/stubs/element.js
@@ -11,4 +11,8 @@ const elementStub = {
 	}
 };
 
+export const unpolyfilledElementStub = {
+	style: {}
+};
+
 export default elementStub;


### PR DESCRIPTION
*  Fixes the isNativeFunction check to accept undefined values
*  Stubs element.animate if it is undefined
*  Logs a warning if element.animte is undefined
*  Logs information if HTMLElement.prototype.animate is undefined
*  Adds a basic test case for element without animate method

closes #369