### PR TITLE
fix: Do not animate for invalid values

### DIFF
--- a/source/library/init-player.js
+++ b/source/library/init-player.js
@@ -58,6 +58,10 @@ export default function initPlayer(element, keyframes, options, render, window =
 		};
 	}
 
+	if (isNaN(options.delay) || isNaN(options.duration) || isNaN(options.iterations)) {
+		return;
+	}
+
 	// Create a proxy for the playerElement if needed
 	// - no native implementation
 	// - render function is given


### PR DESCRIPTION
If invalid values are given to jogwheel skip the animation.

ISSUES CLOSED: #475